### PR TITLE
Fix null pointer derefence when statsd server is unreachable (fixes #2)

### DIFF
--- a/ngx_http_statsd.c
+++ b/ngx_http_statsd.c
@@ -381,7 +381,7 @@ ngx_http_statsd_udp_send(ngx_udp_endpoint_t *l, u_char *buf, size_t len)
     uc = l->udp_connection;
     if (uc->connection == NULL) {
 
-	uc->log = *l->log;
+        uc->log = *l->log;
         uc->log.handler = NULL;
         uc->log.data = NULL;
         uc->log.action = "logging";


### PR DESCRIPTION
See this: http://trac.nginx.org/nginx/ticket/300

Fixes #2

**TL;DR ngx_resolver was causing child process segfaults due to null pointer derefence operations. This has been fixed in February 2012. Since nginx-stats contains some code that looks quite similar to ngx_resolver we should port their patch - and that's what this pull request does :)**
