### PR TITLE
ngx_addon_name and $HTTP_MODULES must same

### DIFF
--- a/config
+++ b/config
@@ -1,4 +1,4 @@
-ngx_addon_name=ngx_http_statsd
+ngx_addon_name=ngx_http_statsd_module
 HTTP_MODULES="$HTTP_MODULES ngx_http_statsd_module"
 NGX_ADDON_SRCS="$NGX_ADDON_SRCS $ngx_addon_dir/ngx_http_statsd.c"
 CORE_LIBS="$CORE_LIBS -lssl"


### PR DESCRIPTION
otherwish ,  nginx: [emerg] can't locate symbol in module "ngx_http_statsd" in  /etc/tengine/tengine.conf will come.
