### PR TITLE
Allow for a dash in the allowed characters map

### DIFF
--- a/ngx_http_statsd.c
+++ b/ngx_http_statsd.c
@@ -166,7 +166,7 @@ ngx_http_statsd_key_get_value(ngx_http_request_t *r, ngx_http_complex_value_t *c
 };
 
 static ngx_str_t
-ngx_http_statsd_key_value(ngx_str_t *value) 
+ngx_http_statsd_key_value(ngx_str_t *value)
 {
 	return *value;
 };
@@ -187,7 +187,7 @@ ngx_http_statsd_metric_get_value(ngx_http_request_t *r, ngx_http_complex_value_t
 };
 
 static ngx_uint_t
-ngx_http_statsd_metric_value(ngx_str_t *value) 
+ngx_http_statsd_metric_value(ngx_str_t *value)
 {
 	ngx_int_t n, m;
 
@@ -199,8 +199,8 @@ ngx_http_statsd_metric_value(ngx_str_t *value)
 	if (value->len > 4 && value->data[value->len - 4] == '.') {
 		n = ngx_atoi(value->data, value->len - 4);
 		m = ngx_atoi(value->data + (value->len - 3), 3);
-		return (ngx_uint_t) ((n * 1000) + m); 
-    	
+		return (ngx_uint_t) ((n * 1000) + m);
+
 	} else {
 		n = ngx_atoi(value->data, value->len);
 		if (n > 0) {
@@ -227,7 +227,7 @@ ngx_http_statsd_valid_get_value(ngx_http_request_t *r, ngx_http_complex_value_t 
 };
 
 static ngx_flag_t
-ngx_http_statsd_valid_value(ngx_str_t *value) 
+ngx_http_statsd_valid_value(ngx_str_t *value)
 {
 	return (ngx_flag_t) (value->len > 0 ? 1 : 0);
 };
@@ -272,7 +272,7 @@ ngx_http_statsd_handler(ngx_http_request_t *r)
 		b = ngx_http_statsd_valid_get_value(r, stat.cvalid, stat.valid);
 
 		if (b == 0 || s.len == 0 || n <= 0) {
-			// Do not log if not valid, key is invalid, or valud is lte 0. 
+			// Do not log if not valid, key is invalid, or valud is lte 0.
 			ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0, "statsd: no value to send");
          	continue;
 		};
@@ -443,11 +443,11 @@ ngx_http_statsd_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
 
 	if (conf->stats == NULL) {
 		sz = (prev->stats != NULL ? prev->stats->nelts : 2);
-		conf->stats = ngx_array_create(cf->pool, sz, sizeof(ngx_statsd_stat_t)); 
+		conf->stats = ngx_array_create(cf->pool, sz, sizeof(ngx_statsd_stat_t));
 		if (conf->stats == NULL) {
         	return NGX_CONF_ERROR;
 		}
-	} 
+	}
 	if (prev->stats != NULL) {
 		prev_stats = prev->stats->elts;
 		for (i = 0; i < prev->stats->nelts; i++) {
@@ -636,7 +636,7 @@ ngx_http_statsd_add_stat(ngx_conf_t *cf, ngx_command_t *cmd, void *conf, ngx_uin
 		}
 	}
 
-	return NGX_CONF_OK; 
+	return NGX_CONF_OK;
 }
 
 static char *
@@ -698,7 +698,7 @@ ngx_escape_statsd_key(u_char *dst, u_char *src, size_t size)
         0xffffffff, /* 1111 1111 1111 1111  1111 1111 1111 1111 */
 
                     /* ?>=< ;:98 7654 3210  /.-, +*)( '&%$ #"!  */
-		0xfc00bfff, /* 1111 1100 0000 0000  1011 1111 1111 1111 */
+		0xfc009fff, /* 1111 1100 0000 0000  1001 1111 1111 1111 */
 
                     /* _^]\ [ZYX WVUT SRQP  ONML KJIH GFED CBA@ */
 		0x78000001, /* 0111 1000 0000 0000  0000 0000 0000 0001 */


### PR DESCRIPTION
Statsd allows for a '-' character and should be also be included here.

For context this is the sanitizer in statsd. https://github.com/etsy/statsd/blob/f8af98b9d74565d43883d5573898dafd6bd2a138/stats.js#L165-L168

Thanks!