### PR TITLE
fix compilation errors with nginx 1.12.0+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,8 +32,8 @@ install:
 script:
   - cd nginx-${X_NGINX_VERSION}
   - ./configure --with-debug --add-module=../nginx-statsd
-  - make > build.log 2>&1 || (cat build.log && exit 1)
-  - sudo make install > build.log 2>&1 || (cat build.log && exit 1)
+  - make
+  - sudo make install
   - nginx -V
   - ldd `which nginx`| grep statsd
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,5 +30,4 @@ script:
   - ./configure --with-debug --add-module=../nginx-statsd
   - make
   - objs/nginx -V
-  - ldd objs/nginx | grep statsd
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,14 @@
 sudo: required
+dist: trusty
+
+os: linux
+
 language: c
+
 compilers:
   - clang
   - gcc
+
 env:
   # Mainline
   - X_NGINX_VERSION=1.13.0
@@ -10,7 +16,7 @@ env:
   - X_NGINX_VERSION=1.12.0
   # Previous stable
   - X_NGINX_VERSION=1.10.3
-sudo: false
+
 addons:
   apt:
     packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,23 @@
+language: c
+compilers:
+  - clang
+  - gcc
+env:
+  # Mainline
+  - X_NGINX_VERSION=1.13.0
+  # Stable
+  - X_NGINX_VERSION=1.12.0
+  # Previous stable
+  - X_NGINX_VERSION=1.10.3
+sudo: false
+addons:
+  apt:
+    packages:
+      - libpcre3-dev
+      - libssl-dev
+install:
+  - wget -O - http://nginx.org/download/nginx-${X_NGINX_VERSION}.tar.gz | tar -xzf -
+  - cd nginx-${X_NGINX_VERSION}
+  - git clone https://github.com/trungtm/nginx-statsd
+  - ./configure --with-debug --add-module=./nginx-statsd
+  - make

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: required
 language: c
 compilers:
   - clang
@@ -15,9 +16,18 @@ addons:
     packages:
       - libpcre3-dev
       - libssl-dev
+cache:
+  apt: true
+
 install:
   - wget -O - http://nginx.org/download/nginx-${X_NGINX_VERSION}.tar.gz | tar -xzf -
-  - cd nginx-${X_NGINX_VERSION}
   - git clone https://github.com/trungtm/nginx-statsd
-  - ./configure --with-debug --add-module=./nginx-statsd
-  - make
+
+script:
+  - cd nginx-${X_NGINX_VERSION}
+  - ./configure --with-debug --add-module=../nginx-statsd
+  - make > build.log 2>&1 || (cat build.log && exit 1)
+  - sudo make install > build.log 2>&1 || (cat build.log && exit 1)
+  - nginx -V
+  - ldd `which nginx`| grep statsd
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,3 @@
-sudo: required
-dist: trusty
-
-os: linux
-
 language: c
 
 compilers:
@@ -17,6 +12,7 @@ env:
   # Previous stable
   - X_NGINX_VERSION=1.10.3
 
+sudo: false
 addons:
   apt:
     packages:
@@ -33,7 +29,6 @@ script:
   - cd nginx-${X_NGINX_VERSION}
   - ./configure --with-debug --add-module=../nginx-statsd
   - make
-  - sudo make install
-  - nginx -V
-  - ldd `which nginx`| grep statsd
+  - objs/nginx -V
+  - ldd objs/nginx | grep statsd
 

--- a/README.mkd
+++ b/README.mkd
@@ -1,5 +1,6 @@
 nginx-statsd
 ============
+[![Build Status](https://travis-ci.org/trungtm/nginx-statsd.svg?branch=master)](https://travis-ci.org/trungtm/nginx-statsd)
 
 An nginx module for sending statistics to statsd.
 

--- a/config
+++ b/config
@@ -1,4 +1,16 @@
 ngx_addon_name=ngx_http_statsd
-HTTP_MODULES="$HTTP_MODULES ngx_http_statsd_module"
-NGX_ADDON_SRCS="$NGX_ADDON_SRCS $ngx_addon_dir/ngx_http_statsd.c"
-CORE_LIBS="$CORE_LIBS -lssl"
+
+if test -n "$ngx_module_link"; then
+    ngx_module_type=HTTP
+    ngx_module_name=ngx_http_statsd_module
+    ngx_module_srcs="$ngx_addon_dir/ngx_http_statsd.c"
+
+    . auto/module
+else
+    HTTP_MODULES="$HTTP_MODULES ngx_http_statsd_module"
+    NGX_ADDON_SRCS="$NGX_ADDON_SRCS $ngx_addon_dir/ngx_http_statsd.c"
+    CORE_LIBS="$CORE_LIBS -lssl"
+fi
+
+USE_OPENSSL=YES
+

--- a/ngx_http_statsd.c
+++ b/ngx_http_statsd.c
@@ -60,8 +60,6 @@ typedef struct {
 	ngx_array_t				*stats;
 } ngx_http_statsd_conf_t;
 
-ngx_int_t ngx_udp_connect(ngx_resolver_connection_t *rec);
-
 static void ngx_statsd_updater_cleanup(void *data);
 static ngx_int_t ngx_http_statsd_udp_send(ngx_udp_endpoint_t *l, u_char *buf, size_t len);
 
@@ -350,6 +348,90 @@ static void ngx_http_statsd_udp_dummy_handler(ngx_event_t *ev)
 {
 }
 
+//ngx_udp_connect()
+static ngx_int_t
+ngx_http_statsd_udp_connect(ngx_resolver_connection_t *rec)
+{
+    int                rc;
+    ngx_int_t          event;
+    ngx_event_t       *rev, *wev;
+    ngx_socket_t       s;
+    ngx_connection_t  *c;
+
+    s = ngx_socket(rec->sockaddr->sa_family, SOCK_DGRAM, 0);
+
+    ngx_log_debug1(NGX_LOG_DEBUG_EVENT, &rec->log, 0, "UDP socket %d", s);
+
+    if (s == (ngx_socket_t) -1) {
+        ngx_log_error(NGX_LOG_ALERT, &rec->log, ngx_socket_errno,
+                      ngx_socket_n " failed");
+        return NGX_ERROR;
+    }
+
+    c = ngx_get_connection(s, &rec->log);
+
+    if (c == NULL) {
+        if (ngx_close_socket(s) == -1) {
+            ngx_log_error(NGX_LOG_ALERT, &rec->log, ngx_socket_errno,
+                          ngx_close_socket_n "failed");
+        }
+
+        return NGX_ERROR;
+    }
+
+    if (ngx_nonblocking(s) == -1) {
+        ngx_log_error(NGX_LOG_ALERT, &rec->log, ngx_socket_errno,
+                      ngx_nonblocking_n " failed");
+
+        goto failed;
+    }
+
+    rev = c->read;
+    wev = c->write;
+
+    rev->log = &rec->log;
+    wev->log = &rec->log;
+
+    rec->udp = c;
+
+    c->number = ngx_atomic_fetch_add(ngx_connection_counter, 1);
+
+    ngx_log_debug3(NGX_LOG_DEBUG_EVENT, &rec->log, 0,
+                   "connect to %V, fd:%d #%uA", &rec->server, s, c->number);
+
+    rc = connect(s, rec->sockaddr, rec->socklen);
+
+    /* TODO: iocp */
+
+    if (rc == -1) {
+        ngx_log_error(NGX_LOG_CRIT, &rec->log, ngx_socket_errno,
+                      "connect() failed");
+
+        goto failed;
+    }
+
+    /* UDP sockets are always ready to write */
+    wev->ready = 1;
+
+    event = (ngx_event_flags & NGX_USE_CLEAR_EVENT) ?
+                /* kqueue, epoll */                 NGX_CLEAR_EVENT:
+                /* select, poll, /dev/poll */       NGX_LEVEL_EVENT;
+                /* eventport event type has no meaning: oneshot only */
+
+    if (ngx_add_event(rev, NGX_READ_EVENT, event) != NGX_OK) {
+        goto failed;
+    }
+
+    return NGX_OK;
+
+failed:
+
+    ngx_close_connection(c);
+    rec->udp = NULL;
+
+    return NGX_ERROR;
+}
+
 static ngx_int_t
 ngx_http_statsd_udp_send(ngx_udp_endpoint_t *l, u_char *buf, size_t len)
 {
@@ -364,7 +446,7 @@ ngx_http_statsd_udp_send(ngx_udp_endpoint_t *l, u_char *buf, size_t len)
         rec->log.data = NULL;
         rec->log.action = "logging";
 
-        if(ngx_udp_connect(rec) != NGX_OK) {
+        if(ngx_http_statsd_udp_connect(rec) != NGX_OK) {
             if(rec->udp != NULL) {
                 ngx_free_connection(rec->udp);
                 rec->udp = NULL;


### PR DESCRIPTION
Since nginx 1.12.0 ngx_udp_connect() is never publicly available, and never have public declaration. So I backport the function from nginx source code to fix compilation errors

https://trac.nginx.org/nginx/ticket/1244