### PR TITLE
port ngx_udp_connect() to fix compilation errors with nginx 1.12.0+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,32 @@
+language: c
+
+compilers:
+  - clang
+  - gcc
+
+env:
+  # Mainline
+  - X_NGINX_VERSION=1.13.0
+  # Stable
+  - X_NGINX_VERSION=1.12.0
+  # Previous stable
+  - X_NGINX_VERSION=1.10.3
+
+sudo: false
+addons:
+  apt:
+    packages:
+      - libpcre3-dev
+      - libssl-dev
+cache:
+  apt: true
+
+install:
+  - wget -O - http://nginx.org/download/nginx-${X_NGINX_VERSION}.tar.gz | tar -xzf -
+  - git clone https://github.com/trungtm/nginx-statsd
+
+script:
+  - cd nginx-${X_NGINX_VERSION}
+  - ./configure --with-debug --add-module=../nginx-statsd
+  - make
+  - objs/nginx -V

--- a/README.mkd
+++ b/README.mkd
@@ -1,5 +1,6 @@
 nginx-statsd
 ============
+[![Build Status](https://travis-ci.org/trungtm/nginx-statsd.svg?branch=master)](https://travis-ci.org/trungtm/nginx-statsd)
 
 An nginx module for sending statistics to statsd.
 

--- a/config
+++ b/config
@@ -1,4 +1,16 @@
 ngx_addon_name=ngx_http_statsd
-HTTP_MODULES="$HTTP_MODULES ngx_http_statsd_module"
-NGX_ADDON_SRCS="$NGX_ADDON_SRCS $ngx_addon_dir/ngx_http_statsd.c"
-CORE_LIBS="$CORE_LIBS -lssl"
+
+if test -n "$ngx_module_link"; then
+    ngx_module_type=HTTP
+    ngx_module_name=ngx_http_statsd_module
+    ngx_module_srcs="$ngx_addon_dir/ngx_http_statsd.c"
+
+    . auto/module
+else
+    HTTP_MODULES="$HTTP_MODULES ngx_http_statsd_module"
+    NGX_ADDON_SRCS="$NGX_ADDON_SRCS $ngx_addon_dir/ngx_http_statsd.c"
+    CORE_LIBS="$CORE_LIBS -lssl"
+fi
+
+USE_OPENSSL=YES
+


### PR DESCRIPTION
Since nginx 1.12.0, ngx_udp_connect() is never publicly available, and never have public declaration.
So I backport the function from nginx source code to fix compilation errors

Issue: https://github.com/zebrafishlabs/nginx-statsd/issues/28

more info:
https://trac.nginx.org/nginx/ticket/1244